### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/memoize/memoize.scrbl
+++ b/memoize/memoize.scrbl
@@ -11,7 +11,7 @@
      (the-eval '(require "main.rkt"))
      the-eval))
 
-@title[#:tag "top"]{@bold{Memoize}: Lightweight Dynamic Programming}
+@title[#:tag "top"]{Memoize: Lightweight Dynamic Programming}
 
 by Dave Herman (@tt{dherman at ccs dot neu dot edu})
 


### PR DESCRIPTION
For visual consistency with other packages within the docs