### PR TITLE
build: fix version declarations

### DIFF
--- a/memoize-doc/info.rkt
+++ b/memoize-doc/info.rkt
@@ -9,7 +9,7 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base"
                    "rackunit-lib"))
 (define build-deps (list "scribble-lib"

--- a/memoize-lib/info.rkt
+++ b/memoize-lib/info.rkt
@@ -10,5 +10,5 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base" "rackunit-lib"))

--- a/memoize-test/info.rkt
+++ b/memoize-test/info.rkt
@@ -8,7 +8,7 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base"
                    "rackunit-lib"
                    "memoize-lib"))

--- a/memoize/info.rkt
+++ b/memoize/info.rkt
@@ -12,4 +12,4 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")


### PR DESCRIPTION
Per [`valid-version?`](https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29), `<maj>` by itself is not a valid version.

See also: https://github.com/racket/racket/pull/4588