### PR TITLE
repair version number to follow the allowed syntax

### DIFF
--- a/memoize-doc/info.rkt
+++ b/memoize-doc/info.rkt
@@ -9,7 +9,7 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base"
                    "rackunit-lib"))
 (define build-deps (list "scribble-lib"

--- a/memoize-lib/info.rkt
+++ b/memoize-lib/info.rkt
@@ -10,5 +10,5 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base" "rackunit-lib"))

--- a/memoize-test/info.rkt
+++ b/memoize-test/info.rkt
@@ -8,7 +8,7 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")
 (define deps (list "base"
                    "rackunit-lib"
                    "memoize-lib"))

--- a/memoize/info.rkt
+++ b/memoize/info.rkt
@@ -12,4 +12,4 @@
   '((p "Updated for Racket.")))
 (define repositories '("4.x"))
 (define required-core-version "5.0")
-(define version "3")
+(define version "3.0")


### PR DESCRIPTION
"3" by itself isn't a well-formed version number, so change to "3.0".