### PR TITLE
Reduce memory usage

### DIFF
--- a/memoize-lib/info.rkt
+++ b/memoize-lib/info.rkt
@@ -11,4 +11,4 @@
 (define repositories '("4.x"))
 (define required-core-version "5.0")
 (define version "3.0")
-(define deps (list "base" "rackunit-lib"))
+(define deps '("base"))

--- a/memoize-lib/memoize/main.rkt
+++ b/memoize-lib/memoize/main.rkt
@@ -1,5 +1,6 @@
-#lang racket
+#lang racket/base
 
+(require (for-syntax racket/base))
 (provide define/memo memo-lambda define/memo* memo-lambda*)
 
 (define (assoc/inner-eq arglist cache)


### PR DESCRIPTION
I noticed that requiring `memoize` would increase memory use significantly over `racket/base`.

Before:

    ~> racket -l racket/base -e '(collect-garbage) (define s (current-memory-use)) (require memoize) (collect-garbage) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
    34.4529

After:

    ~> racket -l racket/base -e '(collect-garbage) (define s (current-memory-use)) (require memoize) (collect-garbage) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
    0.178543